### PR TITLE
Fix reading of NODE_PATH env variable

### DIFF
--- a/src/main/javascript/jvm-npm.js
+++ b/src/main/javascript/jvm-npm.js
@@ -162,7 +162,7 @@ module = (typeof module == 'undefined') ? {} :  module;
     if ( Require.NODE_PATH ) {
       r = r.concat( parsePaths( Require.NODE_PATH ) );
     } else {
-      var NODE_PATH = java.lang.System.getenv.NODE_PATH;
+      var NODE_PATH = java.lang.System.getenv().NODE_PATH;
       if ( NODE_PATH ) {
         r = r.concat( parsePaths( NODE_PATH ) );
       }


### PR DESCRIPTION
NODE_PATH was always empty due to a syntactical error in reading it from System.getenv. Fixes #32.